### PR TITLE
Add DPSPRICE and PRICEASC to pob-dict.txt

### DIFF
--- a/pob-dict.txt
+++ b/pob-dict.txt
@@ -104,6 +104,7 @@ DMGBOTH
 DMGSPELLS
 Dolmur
 DOWNLOADCHARLIST
+DPSPRICE
 dreais
 dropdowns
 Dullson
@@ -281,6 +282,7 @@ POSTFIELDS
 ppoelzl
 Pregenerate
 pregenerated
+PRICEASC
 prolif
 Puddlestomper
 pundm


### PR DESCRIPTION
These are currently causing the spell check workflow to fail.