### PR TITLE
Add Baryanic and Leylines

### DIFF
--- a/poe-dict.txt
+++ b/poe-dict.txt
@@ -235,6 +235,7 @@ Barkskin
 Barrageable
 Bartek's
 Barya
+Baryanic
 baselard
 basemetal
 basetype
@@ -1580,6 +1581,7 @@ lessard
 Levinstone
 levioc
 leyline
+Leylines
 liantra
 libggpk
 lich


### PR DESCRIPTION
already have leyline, but Leylines gets flagged for the PoE2 node `Baryanic Leylines`